### PR TITLE
Updated RedirectController.php to correctly handle requests without transactionId in parameters

### DIFF
--- a/src/Spryker/Zed/AppPayment/Communication/Controller/RedirectController.php
+++ b/src/Spryker/Zed/AppPayment/Communication/Controller/RedirectController.php
@@ -21,7 +21,12 @@ class RedirectController extends AbstractController
 {
     public function indexAction(Request $request): Response
     {
-        $redirectRequestTransfer = (new RedirectRequestTransfer())->setTransactionId((string)$request->query->get('transactionId'));
+        $transactionId = $request->query->get('transactionId');
+        if (empty($transactionId)) {
+            return new Response('Transaction ID is missing.', Response::HTTP_BAD_REQUEST);
+        }
+
+        $redirectRequestTransfer = (new RedirectRequestTransfer())->setTransactionId((string)$transactionId);
         $redirectResponseTransfer = $this->getFacade()->getRedirectUrl($redirectRequestTransfer);
 
         return new RedirectResponse($redirectResponseTransfer->getUrlOrFail());

--- a/src/Spryker/Zed/AppPayment/Communication/Controller/RedirectController.php
+++ b/src/Spryker/Zed/AppPayment/Communication/Controller/RedirectController.php
@@ -22,7 +22,7 @@ class RedirectController extends AbstractController
     public function indexAction(Request $request): Response
     {
         $transactionId = $request->query->get('transactionId');
-        if (empty($transactionId)) {
+        if ($transactionId === null || $transactionId === '') {
             return new Response('Transaction ID is missing.', Response::HTTP_BAD_REQUEST);
         }
 


### PR DESCRIPTION
Fixes the issues from alerts, could be reproduced locally by opening http://apps.spryker.local/app-payment/redirect.  

![image](https://github.com/user-attachments/assets/12d9a3c2-48a0-41c7-a627-37e32cb6f275)


The fix is checked locally.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
