### PR TITLE
Reduce amount of error logs

### DIFF
--- a/src/Spryker/Zed/AppPayment/Business/MessageBroker/CancelPaymentMessageHandler.php
+++ b/src/Spryker/Zed/AppPayment/Business/MessageBroker/CancelPaymentMessageHandler.php
@@ -11,6 +11,7 @@ use Generated\Shared\Transfer\CancelPaymentRequestTransfer;
 use Generated\Shared\Transfer\CancelPaymentResponseTransfer;
 use Generated\Shared\Transfer\CancelPaymentTransfer;
 use Generated\Shared\Transfer\PaymentTransfer;
+use Spryker\Shared\Log\LoggerTrait;
 use Spryker\Zed\AppPayment\Business\MessageBroker\TenantIdentifier\TenantIdentifierExtractor;
 use Spryker\Zed\AppPayment\Business\Payment\Cancel\CancelPayment;
 use Spryker\Zed\AppPayment\Business\Payment\Message\MessageSender;
@@ -19,6 +20,8 @@ use Spryker\Zed\AppPayment\Persistence\AppPaymentRepositoryInterface;
 
 class CancelPaymentMessageHandler implements CancelPaymentMessageHandlerInterface
 {
+    use LoggerTrait;
+
     public function __construct(
         protected AppPaymentRepositoryInterface $appPaymentRepository,
         protected TenantIdentifierExtractor $tenantIdentifierExtractor,
@@ -32,10 +35,16 @@ class CancelPaymentMessageHandler implements CancelPaymentMessageHandlerInterfac
     ): void {
         $tenantIdentifier = $this->tenantIdentifierExtractor->getTenantIdentifierFromMessage($cancelPaymentTransfer);
 
-        $paymentTransfer = $this->appPaymentRepository->getPaymentByTenantIdentifierAndOrderReference(
-            $tenantIdentifier,
-            $cancelPaymentTransfer->getOrderReferenceOrFail(),
-        );
+        try {
+            $paymentTransfer = $this->appPaymentRepository->getPaymentByTenantIdentifierAndOrderReference(
+                $tenantIdentifier,
+                $cancelPaymentTransfer->getOrderReferenceOrFail(),
+            );
+        } catch (PaymentByTenantIdentifierAndOrderReferenceNotFoundException $paymentByTenantIdentifierAndOrderReferenceNotFoundException) {
+            $this->getLogger()->warning($paymentByTenantIdentifierAndOrderReferenceNotFoundException->getMessage());
+
+            return;
+        }
 
         $cancelPaymentRequestTransfer = (new CancelPaymentRequestTransfer())
             ->setTransactionId($paymentTransfer->getTransactionIdOrFail())

--- a/src/Spryker/Zed/AppPayment/Business/MessageBroker/CancelPaymentMessageHandler.php
+++ b/src/Spryker/Zed/AppPayment/Business/MessageBroker/CancelPaymentMessageHandler.php
@@ -17,6 +17,7 @@ use Spryker\Zed\AppPayment\Business\Payment\Cancel\CancelPayment;
 use Spryker\Zed\AppPayment\Business\Payment\Message\MessageSender;
 use Spryker\Zed\AppPayment\Business\Payment\Status\PaymentStatus;
 use Spryker\Zed\AppPayment\Persistence\AppPaymentRepositoryInterface;
+use Spryker\Zed\AppPayment\Persistence\Exception\PaymentByTenantIdentifierAndOrderReferenceNotFoundException;
 
 class CancelPaymentMessageHandler implements CancelPaymentMessageHandlerInterface
 {

--- a/src/Spryker/Zed/AppPayment/Business/MessageBroker/CapturePaymentMessageHandler.php
+++ b/src/Spryker/Zed/AppPayment/Business/MessageBroker/CapturePaymentMessageHandler.php
@@ -18,6 +18,7 @@ use Spryker\Zed\AppPayment\Business\Payment\Capture\PaymentCapturer;
 use Spryker\Zed\AppPayment\Business\Payment\Message\MessageSender;
 use Spryker\Zed\AppPayment\Business\Payment\Status\PaymentStatus;
 use Spryker\Zed\AppPayment\Persistence\AppPaymentRepositoryInterface;
+use Spryker\Zed\AppPayment\Persistence\Exception\PaymentByTenantIdentifierAndOrderReferenceNotFoundException;
 
 class CapturePaymentMessageHandler implements CapturePaymentMessageHandlerInterface
 {

--- a/src/Spryker/Zed/AppPayment/Business/MessageBroker/CapturePaymentMessageHandler.php
+++ b/src/Spryker/Zed/AppPayment/Business/MessageBroker/CapturePaymentMessageHandler.php
@@ -22,7 +22,6 @@ use Spryker\Zed\AppPayment\Persistence\Exception\PaymentByTenantIdentifierAndOrd
 
 class CapturePaymentMessageHandler implements CapturePaymentMessageHandlerInterface
 {
-
     use LoggerTrait;
 
     public function __construct(

--- a/src/Spryker/Zed/AppPayment/Business/MessageBroker/RefundPaymentMessageHandler.php
+++ b/src/Spryker/Zed/AppPayment/Business/MessageBroker/RefundPaymentMessageHandler.php
@@ -36,10 +36,16 @@ class RefundPaymentMessageHandler implements RefundPaymentMessageHandlerInterfac
     {
         $tenantIdentifier = $this->tenantIdentifierExtractor->getTenantIdentifierFromMessage($refundPaymentTransfer);
 
-        $paymentTransfer = $this->appPaymentRepository->getPaymentByTenantIdentifierAndOrderReference(
-            $tenantIdentifier,
-            $refundPaymentTransfer->getOrderReferenceOrFail(),
-        );
+        try {
+            $paymentTransfer = $this->appPaymentRepository->getPaymentByTenantIdentifierAndOrderReference(
+                $tenantIdentifier,
+                $refundPaymentTransfer->getOrderReferenceOrFail(),
+            );
+        } catch (PaymentByTenantIdentifierAndOrderReferenceNotFoundException $paymentByTenantIdentifierAndOrderReferenceNotFoundException) {
+            $this->getLogger()->warning($paymentByTenantIdentifierAndOrderReferenceNotFoundException->getMessage());
+
+            return;
+        }
 
         $refundPaymentRequestTransfer = (new RefundPaymentRequestTransfer())
             ->setTransactionId($paymentTransfer->getTransactionIdOrFail())

--- a/src/Spryker/Zed/AppPayment/Business/MessageBroker/RefundPaymentMessageHandler.php
+++ b/src/Spryker/Zed/AppPayment/Business/MessageBroker/RefundPaymentMessageHandler.php
@@ -19,6 +19,7 @@ use Spryker\Zed\AppPayment\Business\Payment\Message\MessageSender;
 use Spryker\Zed\AppPayment\Business\Payment\Refund\PaymentRefunder;
 use Spryker\Zed\AppPayment\Business\Payment\Refund\PaymentRefundStatus;
 use Spryker\Zed\AppPayment\Persistence\AppPaymentRepositoryInterface;
+use Spryker\Zed\AppPayment\Persistence\Exception\PaymentByTenantIdentifierAndOrderReferenceNotFoundException;
 
 class RefundPaymentMessageHandler implements RefundPaymentMessageHandlerInterface
 {

--- a/tests/SprykerTest/AsyncApi/AppPayment/AppPaymentTests/PaymentCommands/CapturePaymentTest.php
+++ b/tests/SprykerTest/AsyncApi/AppPayment/AppPaymentTests/PaymentCommands/CapturePaymentTest.php
@@ -144,6 +144,7 @@ class CapturePaymentTest extends Unit
         $this->tester->assertPaymentHasStatus($paymentTransfer, PaymentStatus::STATUS_CAPTURE_REQUESTED);
     }
 
+    #[Skip('changed to warning level log')]
     public function testHandleCapturePaymentThrowsExceptionWhenPaymentDoesNotExist(): void
     {
         // Arrange

--- a/tests/SprykerTest/AsyncApi/AppPayment/AppPaymentTests/PaymentCommands/CapturePaymentTest.php
+++ b/tests/SprykerTest/AsyncApi/AppPayment/AppPaymentTests/PaymentCommands/CapturePaymentTest.php
@@ -18,7 +18,6 @@ use Ramsey\Uuid\Uuid;
 use Spryker\Zed\AppPayment\AppPaymentDependencyProvider;
 use Spryker\Zed\AppPayment\Business\Payment\Status\PaymentStatus;
 use Spryker\Zed\AppPayment\Dependency\Plugin\AppPaymentPlatformPluginInterface;
-use Spryker\Zed\AppPayment\Persistence\Exception\PaymentByTenantIdentifierAndOrderReferenceNotFoundException;
 use SprykerTest\AsyncApi\AppPayment\AppPaymentAsyncApiTester;
 use SprykerTest\Shared\Testify\Helper\DependencyHelperTrait;
 
@@ -144,16 +143,13 @@ class CapturePaymentTest extends Unit
         $this->tester->assertPaymentHasStatus($paymentTransfer, PaymentStatus::STATUS_CAPTURE_REQUESTED);
     }
 
-    #[Skip('changed to warning level log')]
-    public function testHandleCapturePaymentThrowsExceptionWhenPaymentDoesNotExist(): void
+    public function testHandleCapturePaymentDoesNotThrowExceptionWhenPaymentDoesNotExist(): void
     {
         // Arrange
         $tenantIdentifier = Uuid::uuid4()->toString();
         $this->tester->haveAppConfigForTenant($tenantIdentifier);
 
         $capturePaymentTransfer = $this->tester->haveCapturePaymentTransfer(['tenantIdentifier' => $tenantIdentifier, 'orderReference' => Uuid::uuid4()->toString()]);
-
-        $this->expectException(PaymentByTenantIdentifierAndOrderReferenceNotFoundException::class);
 
         // Act
         $this->tester->runMessageReceiveTest($capturePaymentTransfer, 'payment-commands');


### PR DESCRIPTION
## PR Description

Reduces the amount of error logs in the monitoring channel when the payment for an order is 
- not created (pre-order-flow), but SCOS sends `CancelPayment` message.
- removed (the app was disconnected and payments are removed), applicable for abandoned Refunds.

example of such error log:
```
Noticed exception 'Symfony\Component\Messenger\Exception\HandlerFailedException' with message 'Handling "Generated\Shared\Transfer\CancelPaymentTransfer" failed: Could not find a payment with the tenantIdentifier "tenant-<GUID>" and orderReference "AMP-31"' in /data/vendor/symfony/messenger/Middleware/HandleMessageMiddleware.php:124
```

Tests with Stripe app: https://github.com/spryker-projects/app-stripe/pull/224


## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
