### PR TITLE
ACP-4760 Allow to return a changed PaymentTransfer from implementatio…

### DIFF
--- a/src/Spryker/Shared/AppPayment/Transfer/app_payment.transfer.xml
+++ b/src/Spryker/Shared/AppPayment/Transfer/app_payment.transfer.xml
@@ -53,6 +53,7 @@
         <property name="isSuccessful" type="bool"/>
         <property name="statusCode" type="int"/>
         <property name="transactionId" type="string"/>
+        <property name="payment" type="Payment"/>
         <property name="preOrderPaymentData" type="array" singular="preOrderPaymentDatum"/>
         <property name="redirectUrl" type="string"/>
         <property name="message" type="string"/>
@@ -85,6 +86,7 @@
     </transfer>
 
     <transfer name="CancelPreOrderPaymentResponse" strict="true">
+        <property name="payment" type="Payment"/>
         <property name="isSuccessful" type="bool"/>
         <property name="statusCode" type="int"/>
         <property name="message" type="string"/>
@@ -98,6 +100,7 @@
     </transfer>
 
     <transfer name="CapturePaymentResponse" strict="true">
+        <property name="payment" type="Payment"/>
         <property name="isSuccessful" type="bool"/>
         <property name="transactionId" type="string"/>
         <property name="message" type="string"/>
@@ -111,6 +114,7 @@
     </transfer>
 
     <transfer name="CancelPaymentResponse" strict="true">
+        <property name="payment" type="Payment"/>
         <property name="isSuccessful" type="bool"/>
         <property name="transactionId" type="string"/>
         <property name="message" type="string"/>
@@ -127,6 +131,7 @@
     </transfer>
 
     <transfer name="RefundPaymentResponse" strict="true">
+        <property name="payment" type="Payment"/>
         <property name="isSuccessful" type="bool"/>
         <property name="refundId" type="string"/>
         <property name="message" type="string"/>

--- a/src/Spryker/Zed/AppPayment/Business/AppPaymentBusinessFactory.php
+++ b/src/Spryker/Zed/AppPayment/Business/AppPaymentBusinessFactory.php
@@ -255,6 +255,7 @@ class AppPaymentBusinessFactory extends AbstractBusinessFactory
             $this->getPlatformPlugin(),
             $this->createPaymentRefundValidator(),
             $this->getEntityManager(),
+            $this->createPaymentWriter(),
             $this->getConfig(),
             $this->createAppConfigLoader(),
         );

--- a/src/Spryker/Zed/AppPayment/Business/Payment/Cancel/CancelPayment.php
+++ b/src/Spryker/Zed/AppPayment/Business/Payment/Cancel/CancelPayment.php
@@ -62,8 +62,10 @@ class CancelPayment
         }
 
         /** @phpstan-var \Generated\Shared\Transfer\CancelPaymentResponseTransfer */
-        return $this->getTransactionHandler()->handleTransaction(function () use ($cancelPaymentRequestTransfer, $cancelPaymentResponseTransfer): \Generated\Shared\Transfer\CancelPaymentResponseTransfer {
-            $this->savePayment($cancelPaymentRequestTransfer->getPaymentOrFail(), $cancelPaymentResponseTransfer->getStatusOrFail());
+        return $this->getTransactionHandler()->handleTransaction(function () use ($cancelPaymentRequestTransfer, $cancelPaymentResponseTransfer): CancelPaymentResponseTransfer {
+            $paymentTransfer = $cancelPaymentResponseTransfer->getPayment() ?? $cancelPaymentRequestTransfer->getPaymentOrFail();
+
+            $this->savePayment($paymentTransfer, $cancelPaymentResponseTransfer->getStatusOrFail());
 
             return $cancelPaymentResponseTransfer;
         });

--- a/src/Spryker/Zed/AppPayment/Business/Payment/Capture/PaymentCapturer.php
+++ b/src/Spryker/Zed/AppPayment/Business/Payment/Capture/PaymentCapturer.php
@@ -50,8 +50,10 @@ class PaymentCapturer
         }
 
         /** @phpstan-var \Generated\Shared\Transfer\CapturePaymentResponseTransfer */
-        return $this->getTransactionHandler()->handleTransaction(function () use ($capturePaymentRequestTransfer, $capturePaymentResponseTransfer): \Generated\Shared\Transfer\CapturePaymentResponseTransfer {
-            $this->savePayment($capturePaymentRequestTransfer->getPaymentOrFail(), $capturePaymentResponseTransfer->getStatusOrFail());
+        return $this->getTransactionHandler()->handleTransaction(function () use ($capturePaymentRequestTransfer, $capturePaymentResponseTransfer): CapturePaymentResponseTransfer {
+            $paymentTransfer = $capturePaymentResponseTransfer->getPayment() ?? $capturePaymentRequestTransfer->getPaymentOrFail();
+
+            $this->savePayment($paymentTransfer, $capturePaymentResponseTransfer->getStatusOrFail());
 
             return $capturePaymentResponseTransfer;
         });

--- a/tests/SprykerTest/AsyncApi/AppPayment/AppPaymentTests/PaymentCommands/RefundPaymentTest.php
+++ b/tests/SprykerTest/AsyncApi/AppPayment/AppPaymentTests/PaymentCommands/RefundPaymentTest.php
@@ -15,6 +15,7 @@ use Generated\Shared\Transfer\MessageAttributesTransfer;
 use Generated\Shared\Transfer\PaymentRefundedTransfer;
 use Generated\Shared\Transfer\PaymentRefundFailedTransfer;
 use Generated\Shared\Transfer\PaymentTransfer;
+use Generated\Shared\Transfer\PaymentUpdatedTransfer;
 use Generated\Shared\Transfer\RefundPaymentRequestTransfer;
 use Generated\Shared\Transfer\RefundPaymentResponseTransfer;
 use Generated\Shared\Transfer\RefundPaymentTransfer;
@@ -100,6 +101,48 @@ class RefundPaymentTest extends Unit
         // Assert
         $this->tester->assertPaymentRefundIsInStatus($refundId, PaymentRefundStatus::SUCCEEDED);
         $this->tester->assertMessageWasSent(PaymentRefundedTransfer::class);
+    }
+
+    public function testRefundPaymentMessageSendsPaymentRefundedMessageAndCreatesPaymentRefundWhenPaymentIsInCapturedStateAndPersistsDetailsFromTheImplementationReturnedPaymentAndSendsAPaymentUpdatedMessage(): void
+    {
+        // Arrange
+        $tenantIdentifier = Uuid::uuid4()->toString();
+        $transactionId = Uuid::uuid4()->toString();
+        $refundId = Uuid::uuid4()->toString();
+        $this->tester->haveAppConfigForTenant($tenantIdentifier);
+        $paymentTransfer = $this->tester->havePaymentForTransactionId($transactionId, $tenantIdentifier, PaymentStatus::STATUS_CAPTURED);
+
+        $refundPaymentTransfer = $this->tester->haveRefundPaymentTransfer([
+            MessageAttributesTransfer::TENANT_IDENTIFIER => $tenantIdentifier,
+            RefundPaymentTransfer::ORDER_REFERENCE => $paymentTransfer->getOrderReference(),
+        ]);
+        $refundPaymentResponseTransfer = (new RefundPaymentResponseTransfer())
+            ->setIsSuccessful(true)
+            ->setRefundId($refundId)
+            ->setStatus(PaymentRefundStatus::SUCCEEDED);
+
+        $platformPluginMock = Stub::makeEmpty(AppPaymentPlatformPluginInterface::class, [
+            'refundPayment' => function (RefundPaymentRequestTransfer $refundPaymentRequestTransfer) use ($refundPaymentResponseTransfer, $paymentTransfer) {
+                $this->assertInstanceOf(AppConfigTransfer::class, $refundPaymentRequestTransfer->getAppConfig());
+                $this->assertInstanceOf(PaymentTransfer::class, $refundPaymentRequestTransfer->getPayment());
+
+                $paymentTransfer->setDetails('{"foo":"bar"}');
+                $refundPaymentResponseTransfer->setPayment($paymentTransfer);
+
+                return $refundPaymentResponseTransfer;
+            },
+        ]);
+
+        $this->getDependencyHelper()->setDependency(AppPaymentDependencyProvider::PLUGIN_PLATFORM, $platformPluginMock);
+
+        // Act: This will trigger the MessageHandlerPlugin for this message.
+        $this->tester->runMessageReceiveTest($refundPaymentTransfer, 'payment-commands');
+
+        // Assert
+        $this->tester->assertPaymentRefundIsInStatus($refundId, PaymentRefundStatus::SUCCEEDED);
+        $this->tester->assertPaymentHasDetails($paymentTransfer, '{"foo":"bar"}');
+        $this->tester->assertMessageWasSent(PaymentRefundedTransfer::class);
+        $this->tester->assertMessageWasSent(PaymentUpdatedTransfer::class);
     }
 
     /**

--- a/tests/SprykerTest/Shared/AppPayment/_support/Helper/AppPaymentAssertionHelper.php
+++ b/tests/SprykerTest/Shared/AppPayment/_support/Helper/AppPaymentAssertionHelper.php
@@ -21,4 +21,10 @@ class AppPaymentAssertionHelper extends Module
         $updatedPaymentTransfer = $this->getPaymentHelper()->getPaymentTransferByTransactionId($paymentTransfer->getTransactionId());
         $this->assertEquals($expectedStatus, $updatedPaymentTransfer->getStatus(), sprintf('Expected payment to have status "%s" but status "%s" was found.', $expectedStatus, $updatedPaymentTransfer->getStatus()));
     }
+
+    public function assertPaymentHasDetails(PaymentTransfer $paymentTransfer, string $expectedDetails): void
+    {
+        $updatedPaymentTransfer = $this->getPaymentHelper()->getPaymentTransferByTransactionId($paymentTransfer->getTransactionId());
+        $this->assertEquals($expectedDetails, $updatedPaymentTransfer->getDetails(), sprintf('Expected payment to have details "%s" but details "%s" was found.', $expectedDetails, $updatedPaymentTransfer->getDetails()));
+    }
 }


### PR DESCRIPTION
…ns to be able to persist changes on the Payment.

## PR Description
- Added possibility to return a changed Payment object from the implementation and persist it properly.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/app-payment/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
